### PR TITLE
Various fixes, add room name to scene list

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
 	"id": "nl.luxaflex.powerview",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"compatibility": ">=1.5.0",
 	"sdk": 2,
 	"name": {
@@ -132,6 +132,10 @@
 		"developers": [{
 			"name": "HUSS BV",
 			"email": "support@huss.nl"
+		},
+		{
+			"name": "Rogier Hofboer",
+			"email": "rogier@hofboer.nl"
 		}]
 	}
 }

--- a/drivers/nl.luxaflex.powerview.hub/flow/actions.js
+++ b/drivers/nl.luxaflex.powerview.hub/flow/actions.js
@@ -63,7 +63,7 @@ sceneSetActionArg.registerAutocompleteListener( ( query, args ) => {
 	//console.log("getSceneList" + JSON.stringify(args));
 	
 	let ip = ((args || {}).device || {}).ip;
-	let url = "http://" + ip +"/api/scenes";
+	let url = "http://" + ip +"/api/scenes?";
 	//console.log("url" + url);
 	return http.json(url).then((data) => {
 		//console.log(JSON.stringify(data));
@@ -96,7 +96,7 @@ sceneCollectionSetActionArg.registerAutocompleteListener( ( query, args ) => {
 	//console.log("getSceneList" + JSON.stringify(args));
 	
 	let ip = ((args || {}).device || {}).ip;
-	let url = "http://" + ip +"/api/scenecollections";
+	let url = "http://" + ip +"/api/scenecollections?";
 	//console.log("url" + url);
 	return http.json(url).then((data) => {
 		//console.log(JSON.stringify(data));

--- a/drivers/nl.luxaflex.powerview.hub/flow/actions.js
+++ b/drivers/nl.luxaflex.powerview.hub/flow/actions.js
@@ -82,7 +82,7 @@ sceneSetActionArg.registerAutocompleteListener( ( query, args ) => {
 
 		return results = results.filter(( resultsItem ) => {
 					return resultsItem.name.toLowerCase().indexOf( query.toLowerCase() ) > -1;
-				});
+				}).sort((a,b) => { return (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0);});
 		
     }).catch(() => {
 		console.log('Cannot get scenes');
@@ -115,7 +115,7 @@ sceneCollectionSetActionArg.registerAutocompleteListener( ( query, args ) => {
 
 		return results = results.filter(( resultsItem ) => {
 					return resultsItem.name.toLowerCase().indexOf( query.toLowerCase() ) > -1;
-				});
+				}).sort((a,b) => { return (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0);});
 		
     }).catch(() => {
 		console.log('Cannot get sceneCollections');

--- a/drivers/nl.luxaflex.powerview.hub/flow/actions.js
+++ b/drivers/nl.luxaflex.powerview.hub/flow/actions.js
@@ -70,7 +70,7 @@ sceneSetActionArg.registerAutocompleteListener( ( query, args ) => {
 		let results = [];
 		 if (data.sceneData){
 		    data.sceneData.forEach((scene) => {
-				 let sceneName = new Buffer(scene.name, 'base64').toString('ascii');
+				 let sceneName = new Buffer(scene.name, 'base64').toString('utf8');
 				 results.push(
 					 {
 					   "id": scene.id,
@@ -103,7 +103,7 @@ sceneCollectionSetActionArg.registerAutocompleteListener( ( query, args ) => {
 		let results = [];
 		 if (data.sceneCollectionData){
 		    data.sceneCollectionData.forEach((sceneCollection) => {
-				 let sceneCollectionName = new Buffer(sceneCollection.name, 'base64').toString('ascii');
+				 let sceneCollectionName = new Buffer(sceneCollection.name, 'base64').toString('utf8');
 				 results.push(
 					 {
 					   "id": sceneCollection.id,

--- a/drivers/nl.luxaflex.powerview.hub/flow/actions.js
+++ b/drivers/nl.luxaflex.powerview.hub/flow/actions.js
@@ -63,32 +63,46 @@ sceneSetActionArg.registerAutocompleteListener( ( query, args ) => {
 	//console.log("getSceneList" + JSON.stringify(args));
 	
 	let ip = ((args || {}).device || {}).ip;
-	let url = "http://" + ip +"/api/scenes?";
-	//console.log("url" + url);
-	return http.json(url).then((data) => {
-		//console.log(JSON.stringify(data));
-		let results = [];
-		 if (data.sceneData){
-		    data.sceneData.forEach((scene) => {
-				 let sceneName = new Buffer(scene.name, 'base64').toString('utf8');
-				 results.push(
-					 {
-					   "id": scene.id,
-					   "name": sceneName + " (" + scene.id + ")"
-					 }
-				 );
+	let urlRooms = "http://" + ip + "/api/rooms?";
+
+	return http.json(urlRooms).then((dataRooms) => {
+		let rooms = {};
+		 if (dataRooms.roomData){
+			dataRooms.roomData.forEach((room) => {
+				let roomName = new Buffer(room.name, 'base64').toString('utf8');
+				rooms[room.id] = roomName;
 			});
 		 }
-
-		return results = results.filter(( resultsItem ) => {
-					return resultsItem.name.toLowerCase().indexOf( query.toLowerCase() ) > -1;
-				}).sort((a,b) => { return (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0);});
 		
-    }).catch(() => {
-		console.log('Cannot get scenes');
-		throw new Error('Cannot get scenes');
+		let url = "http://" + ip +"/api/scenes?";
+		//console.log("url" + url);
+		return http.json(url).then((data) => {
+			//console.log(JSON.stringify(data));
+			let results = [];
+			 if (data.sceneData){
+				data.sceneData.forEach((scene) => {
+					 let sceneName = new Buffer(scene.name, 'base64').toString('utf8');
+					 results.push(
+						 {
+						   "id": scene.id,
+						   "name": rooms[scene.roomId] + " - " + sceneName + " (" + scene.id + ")"
+						 }
+					 );
+				});
+			 }
+
+			return results = results.filter(( resultsItem ) => {
+						return resultsItem.name.toLowerCase().indexOf( query.toLowerCase() ) > -1;
+					}).sort((a,b) => { return (a.name > b.name) ? 1 : ((b.name > a.name) ? -1 : 0);});
+
+		}).catch(() => {
+			console.log('Cannot get scenes');
+			throw new Error('Cannot get scenes');
+		});
+	}).catch(() => {
+		console.log('Cannot get rooms');
+		throw new Error('Cannot get rooms');
 	});
-	
 });
 
 let sceneCollectionSetActionArg = sceneCollectionSetAction.getArgument('nl.luxaflex.powerview.sceneCollectionAutocomplete');

--- a/drivers/nl.luxaflex.powerview.hub/flow/actions.js
+++ b/drivers/nl.luxaflex.powerview.hub/flow/actions.js
@@ -96,7 +96,7 @@ sceneCollectionSetActionArg.registerAutocompleteListener( ( query, args ) => {
 	//console.log("getSceneList" + JSON.stringify(args));
 	
 	let ip = ((args || {}).device || {}).ip;
-	let url = "http://" + ip +"/api/sceneCollections";
+	let url = "http://" + ip +"/api/scenecollections";
 	//console.log("url" + url);
 	return http.json(url).then((data) => {
 		//console.log(JSON.stringify(data));

--- a/drivers/nl.luxaflex.powerview.hub/flow/actions.js
+++ b/drivers/nl.luxaflex.powerview.hub/flow/actions.js
@@ -60,7 +60,7 @@ sceneCollectionSetAction.register().registerRunListener(( args, state ) => {
 
 let sceneSetActionArg = sceneSetAction.getArgument('nl.luxaflex.powerview.sceneAutocomplete');
 sceneSetActionArg.registerAutocompleteListener( ( query, args ) => {
-	console.log("getSceneList" + JSON.stringify(args));
+	//console.log("getSceneList" + JSON.stringify(args));
 	
 	let ip = ((args || {}).device || {}).ip;
 	let url = "http://" + ip +"/api/scenes";
@@ -93,7 +93,7 @@ sceneSetActionArg.registerAutocompleteListener( ( query, args ) => {
 
 let sceneCollectionSetActionArg = sceneCollectionSetAction.getArgument('nl.luxaflex.powerview.sceneCollectionAutocomplete');
 sceneCollectionSetActionArg.registerAutocompleteListener( ( query, args ) => {
-	console.log("getSceneList" + JSON.stringify(args));
+	//console.log("getSceneList" + JSON.stringify(args));
 	
 	let ip = ((args || {}).device || {}).ip;
 	let url = "http://" + ip +"/api/sceneCollections";


### PR DESCRIPTION
I've fixed some things and added the room name to the scene list.
At least in my setup, the scenes for a single room do not have the name of the room in their name,
so they are called "Up", "Down" etc. Without adding the room name it is hard to tell the room the scene is for. 

Note: Maybe the scene(collection)id should be removed from the displayed name, since it does not make sense for normal users. I haven't done this yet.